### PR TITLE
Add OC Network cable support.

### DIFF
--- a/src/main/java/pl/asie/ynot/YNot.java
+++ b/src/main/java/pl/asie/ynot/YNot.java
@@ -72,7 +72,7 @@ public class YNot {
 				xNet.registerChannelType(new FlamingoChannelType());
 			}
 
-			if (enableOC)
+			if (enableOC) {
 				xNet.registerChannelType(new OCChannelType());
 			}
 
@@ -97,7 +97,7 @@ public class YNot {
 		}
 
 		if (Loader.isModLoaded("opencomputers")) {
-			enableOC = config.getBoolean("opencomputersCable", "features", true, "Adds the ability to send network messages and use components.")
+			enableOC = config.getBoolean("opencomputersCable", "features", true, "Adds the ability to send network messages and use components.");
 		}
 
 		if (config.hasChanged()) {

--- a/src/main/java/pl/asie/ynot/YNot.java
+++ b/src/main/java/pl/asie/ynot/YNot.java
@@ -41,6 +41,7 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import pl.asie.ynot.flamingo.FlamingoChannelType;
 import pl.asie.ynot.mekanism.GasChannelType;
+import pl.asie.ynot.oc.OCChannelType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -58,7 +59,7 @@ public class YNot {
 	private static Configuration config;
 
 	public static int maxGasRateAdvanced, maxGasRateNormal;
-	private static boolean enableMekanismGas, enableWiggles;
+	private static boolean enableMekanismGas, enableWiggles, enableOC;
 
 	public static class XNetHook implements Function<IXNet, Void> {
 		@Override
@@ -69,6 +70,10 @@ public class YNot {
 
 			if (enableWiggles) {
 				xNet.registerChannelType(new FlamingoChannelType());
+			}
+
+			if (enableOC)
+				xNet.registerChannelType(new OCChannelType());
 			}
 
 			return null;
@@ -89,6 +94,10 @@ public class YNot {
 
 		if (Loader.isModLoaded("flamingo")) {
 			enableWiggles = config.getBoolean("flamingoWiggles", "features", true, "Don't question it.");
+		}
+
+		if (Loader.isModLoaded("opencomputers")) {
+			enableOC = config.getBoolean("opencomputersCable", "features", true, "Adds the ability to send network messages and use components.")
 		}
 
 		if (config.hasChanged()) {

--- a/src/main/java/pl/asie/ynot/oc/OCChannelSettings.java
+++ b/src/main/java/pl/asie/ynot/oc/OCChannelSettings.java
@@ -68,6 +68,23 @@ public class OCChannelSettings extends TraitedChannelSettings {
                 cachedNodes.add(env.node());
             }
         }
+
+        connectors = context.getRoutedConnectors(channel);
+        for (Map.Entry<SidedConsumer, IConnectorSettings> entry : connectors.entrySet()) {
+            OCConnectorSettings settings = (OCConnectorSettings) entry.getValue();
+
+            BlockPos pos = context.findConsumerPosition(entry.getKey().getConsumerId());
+            pos = pos.offset(entry.getKey().getSide());
+
+            Environment env = getEnvironment(world, pos);
+
+            if(env == null) { continue; }
+            if(env.node() != null && !env.node().isNeighborOf(channelNode)) {
+                env.node().connect(channelNode);
+                cachedNodes.add(env.node());
+            }
+        }
+
     }
 
     @Override

--- a/src/main/java/pl/asie/ynot/oc/OCChannelSettings.java
+++ b/src/main/java/pl/asie/ynot/oc/OCChannelSettings.java
@@ -1,0 +1,97 @@
+package pl.asie.ynot.oc;
+
+import li.cil.oc.api.Network;
+import li.cil.oc.api.network.Environment;
+import li.cil.oc.api.network.Node;
+import li.cil.oc.api.network.Visibility;
+import li.cil.oc.api.prefab.AbstractManagedEnvironment;
+import mcjty.xnet.api.channels.IChannelSettings;
+import mcjty.xnet.api.channels.IConnectorSettings;
+import mcjty.xnet.api.channels.IControllerContext;
+import mcjty.xnet.api.gui.IEditorGui;
+import mcjty.xnet.api.gui.IndicatorIcon;
+import mcjty.xnet.api.keys.SidedConsumer;
+import net.minecraft.nbt.NBTTagCompound;
+import pl.asie.ynot.traits.TraitedChannelSettings;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class OCChannelSettings extends TraitedChannelSettings {
+    Node channelNode;
+    Set<Node> cachedNodes = null;
+
+    class DummyEnvironment extends AbstractManagedEnvironment {
+        DummyEnvironment() {
+            this.setNode(Network.newNode(this, Visibility.Neighbors).create());
+        }
+    }
+
+    public OCChannelSettings() {
+        super();
+
+        channelNode = new DummyEnvironment().node();
+        cachedNodes = null;
+    }
+
+    @Override
+    public void tick(int channel, IControllerContext context) {
+        if(cachedNodes != null) { return; }
+        cachedNodes = new HashSet<>();
+
+        Map<SidedConsumer, IConnectorSettings> connectors = context.getConnectors(channel);
+        for (Map.Entry<SidedConsumer, IConnectorSettings> entry : connectors.entrySet()) {
+            OCConnectorSettings settings = (OCConnectorSettings) entry.getValue();
+            Environment env = (Environment)
+                    context.getControllerWorld()
+                        .getTileEntity(context.findConsumerPosition(entry.getKey().getConsumerId())
+                            .add(entry.getKey().getSide().getDirectionVec()));
+
+            if(env == null) { continue; }
+            if(env.node() != null && !env.node().isNeighborOf(channelNode)) {
+                env.node().connect(channelNode);
+                cachedNodes.add(env.node());
+            }
+        }
+    }
+
+    @Override
+    public void cleanCache() {
+        if(cachedNodes == null) { return; }
+
+        for(Node node : cachedNodes) {
+            node.disconnect(channelNode);
+        }
+
+        cachedNodes = null;
+    }
+
+    @Override
+    public int getColors() {
+        return 0;
+    }
+
+    @Nullable
+    @Override
+    public IndicatorIcon getIndicatorIcon() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getIndicator() {
+        return null;
+    }
+
+    @Override
+    public boolean isEnabled(String tag) {
+        return false;
+    }
+
+    @Override
+    public void createGui(IEditorGui gui) {
+
+    }
+}

--- a/src/main/java/pl/asie/ynot/oc/OCChannelType.java
+++ b/src/main/java/pl/asie/ynot/oc/OCChannelType.java
@@ -1,0 +1,42 @@
+package pl.asie.ynot.oc;
+
+import li.cil.oc.api.network.Environment;
+import mcjty.xnet.api.channels.IChannelSettings;
+import mcjty.xnet.api.channels.IChannelType;
+import mcjty.xnet.api.channels.IConnectorSettings;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class OCChannelType implements IChannelType {
+
+    @Override
+    public String getID() {
+        return "ynot.opencomputers";
+    }
+
+    @Override
+    public String getName() {
+        return "OpenComputers";
+    }
+
+    @Override
+    public boolean supportsBlock(@Nonnull World world, @Nonnull BlockPos pos, @Nullable EnumFacing side) {
+        return world.getTileEntity(pos) instanceof Environment;
+    }
+
+    @Nonnull
+    @Override
+    public IConnectorSettings createConnector(@Nonnull EnumFacing side) {
+        return new OCConnectorSettings(side);
+    }
+
+    @Nonnull
+    @Override
+    public IChannelSettings createChannel() {
+        return new OCChannelSettings();
+    }
+}

--- a/src/main/java/pl/asie/ynot/oc/OCChannelType.java
+++ b/src/main/java/pl/asie/ynot/oc/OCChannelType.java
@@ -12,7 +12,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class OCChannelType implements IChannelType {
-
     @Override
     public String getID() {
         return "ynot.opencomputers";
@@ -25,7 +24,7 @@ public class OCChannelType implements IChannelType {
 
     @Override
     public boolean supportsBlock(@Nonnull World world, @Nonnull BlockPos pos, @Nullable EnumFacing side) {
-        return world.getTileEntity(pos) instanceof Environment;
+        return world.getTileEntity(pos.offset(side)) instanceof Environment;
     }
 
     @Nonnull

--- a/src/main/java/pl/asie/ynot/oc/OCConnectorSettings.java
+++ b/src/main/java/pl/asie/ynot/oc/OCConnectorSettings.java
@@ -1,0 +1,40 @@
+package pl.asie.ynot.oc;
+
+import li.cil.oc.api.network.Environment;
+import mcjty.xnet.api.channels.IControllerContext;
+import mcjty.xnet.api.gui.IEditorGui;
+import mcjty.xnet.api.gui.IndicatorIcon;
+import net.minecraft.util.EnumFacing;
+import pl.asie.ynot.YNot;
+import pl.asie.ynot.traits.TraitedConnectorSettings;
+
+import javax.annotation.Nullable;
+
+public class OCConnectorSettings extends TraitedConnectorSettings {
+    OCConnectorSettings(EnumFacing side) {
+        super(side);
+    }
+
+    @Nullable
+    @Override
+    public IndicatorIcon getIndicatorIcon() {
+        return new IndicatorIcon(YNot.iconGui, 11, 0, 11, 10);
+    }
+
+    @Nullable
+    @Override
+    public String getIndicator() {
+        return null;
+    }
+
+    @Override
+    public boolean isEnabled(String tag) {
+        return true;
+    }
+
+
+    @Override
+    public void createGui(IEditorGui gui) {
+
+    }
+}


### PR DESCRIPTION
This makes it possible to send modem messages and access components from OC using XNet cables and connectors.

A possible improvement would be to make it possible to choose which you want from the controller,  but I decided to submit the PR with the basic workings first.