### PR TITLE
Add 'network only' mode to OC support.

### DIFF
--- a/src/main/java/pl/asie/ynot/enums/OCNetworkMode.java
+++ b/src/main/java/pl/asie/ynot/enums/OCNetworkMode.java
@@ -1,0 +1,6 @@
+package pl.asie.ynot.enums;
+
+public enum OCNetworkMode {
+    COMPONENT_AND_NETWORK,
+    NETWORK_ONLY
+}

--- a/src/main/java/pl/asie/ynot/oc/OCConnectorSettings.java
+++ b/src/main/java/pl/asie/ynot/oc/OCConnectorSettings.java
@@ -6,13 +6,19 @@ import mcjty.xnet.api.gui.IEditorGui;
 import mcjty.xnet.api.gui.IndicatorIcon;
 import net.minecraft.util.EnumFacing;
 import pl.asie.ynot.YNot;
+import pl.asie.ynot.enums.OCNetworkMode;
+import pl.asie.ynot.traits.TraitEnum;
 import pl.asie.ynot.traits.TraitedConnectorSettings;
 
 import javax.annotation.Nullable;
 
 public class OCConnectorSettings extends TraitedConnectorSettings {
+    TraitEnum<OCNetworkMode> networkMode;
+
     OCConnectorSettings(EnumFacing side) {
         super(side);
+
+        register(networkMode = new TraitEnum<>("mode", OCNetworkMode.class, OCNetworkMode.COMPONENT_AND_NETWORK));
     }
 
     @Nullable
@@ -35,6 +41,6 @@ public class OCConnectorSettings extends TraitedConnectorSettings {
 
     @Override
     public void createGui(IEditorGui gui) {
-
+        networkMode.apply("Components + Network or Network only.", gui);
     }
 }


### PR DESCRIPTION
This turned out to be rather simple. Adds an option per-connector for "Components and Network" or "Network only" -- if set to "Network only"  only modem messages will get forwarded to the connected device.