### PR TITLE
Use caps instead of instanceof for OCChannelType and OCChannelSettings.

### DIFF
--- a/src/main/java/pl/asie/ynot/YNot.java
+++ b/src/main/java/pl/asie/ynot/YNot.java
@@ -95,7 +95,6 @@ public class YNot {
 			if (enableOC) {
 				xNet.registerChannelType(new OCChannelType());
 				YNotConnectable.add(capOCEnv, capOCSidedEnv);
-				YNotConnectable.add(capOCEnv.getClass(), capOCSidedEnv.getClass());
 				needsCustomConnections = true;
 			}
 

--- a/src/main/java/pl/asie/ynot/oc/OCChannelSettings.java
+++ b/src/main/java/pl/asie/ynot/oc/OCChannelSettings.java
@@ -8,9 +8,12 @@ import mcjty.xnet.api.channels.IControllerContext;
 import mcjty.xnet.api.gui.IEditorGui;
 import mcjty.xnet.api.gui.IndicatorIcon;
 import mcjty.xnet.api.keys.SidedConsumer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
 import pl.asie.ynot.YNot;
 import pl.asie.ynot.enums.OCNetworkMode;
 import pl.asie.ynot.traits.TraitedChannelSettings;
@@ -21,6 +24,12 @@ import java.util.Map;
 import java.util.Set;
 
 public class OCChannelSettings extends TraitedChannelSettings {
+    @CapabilityInject(Environment.class)
+    private static Capability<Environment> ENVIRONMENT_CAPABILITY;
+
+    @CapabilityInject(SidedEnvironment.class)
+    private static Capability<SidedEnvironment> SIDED_ENVIRONMENT_CAPABILITY;
+
     Node channelNode;
     Set<Node> componentNodes;
     Set<Node> networkNodes;
@@ -52,10 +61,15 @@ public class OCChannelSettings extends TraitedChannelSettings {
     }
 
     private Node getNode(World world, BlockPos pos, EnumFacing side) {
-        if (world.getTileEntity(pos) instanceof SidedEnvironment) {
-            return ((SidedEnvironment) world.getTileEntity(pos)).sidedNode(side.getOpposite());
-        } else if(world.getTileEntity(pos) instanceof Environment) {
-            return ((Environment) world.getTileEntity(pos)).node();
+        TileEntity tile = world.getTileEntity(pos);
+        if(tile == null) {
+            return null;
+        }
+
+        if (tile.hasCapability(SIDED_ENVIRONMENT_CAPABILITY, side)) {
+            return tile.getCapability(SIDED_ENVIRONMENT_CAPABILITY, side).sidedNode(side.getOpposite());
+        } else if (tile.hasCapability(ENVIRONMENT_CAPABILITY, side)) {
+            return tile.getCapability(ENVIRONMENT_CAPABILITY, side).node();
         } else {
             return null;
         }

--- a/src/main/java/pl/asie/ynot/oc/OCChannelType.java
+++ b/src/main/java/pl/asie/ynot/oc/OCChannelType.java
@@ -5,14 +5,24 @@ import li.cil.oc.api.network.SidedEnvironment;
 import mcjty.xnet.api.channels.IChannelSettings;
 import mcjty.xnet.api.channels.IChannelType;
 import mcjty.xnet.api.channels.IConnectorSettings;
+import mekanism.api.gas.IGasHandler;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityInject;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class OCChannelType implements IChannelType {
+    @CapabilityInject(Environment.class)
+    private static Capability<Environment> ENVIRONMENT_CAPABILITY;
+
+    @CapabilityInject(SidedEnvironment.class)
+    private static Capability<SidedEnvironment> SIDED_ENVIRONMENT_CAPABILITY;
+
     @Override
     public String getID() {
         return "ynot.opencomputers";
@@ -25,8 +35,17 @@ public class OCChannelType implements IChannelType {
 
     @Override
     public boolean supportsBlock(@Nonnull World world, @Nonnull BlockPos pos, @Nullable EnumFacing side) {
-        return world.getTileEntity(pos.offset(side)) instanceof Environment
-                || world.getTileEntity(pos.offset(side)) instanceof SidedEnvironment;
+        TileEntity tile = world.getTileEntity(pos.offset(side));
+
+        if (tile != null) {
+            if(tile.hasCapability(SIDED_ENVIRONMENT_CAPABILITY, side)) {
+                return true;
+            } else if(tile.hasCapability(ENVIRONMENT_CAPABILITY, side)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Nonnull

--- a/src/main/java/pl/asie/ynot/oc/OCConnectorSettings.java
+++ b/src/main/java/pl/asie/ynot/oc/OCConnectorSettings.java
@@ -20,7 +20,7 @@ public class OCConnectorSettings extends TraitedConnectorSettings {
     OCConnectorSettings(EnumFacing side) {
         super(side);
 
-        register(networkMode = new TraitEnum<>("mode", OCNetworkMode.class, OCNetworkMode.COMPONENT_AND_NETWORK));
+        register(networkMode = new TraitEnum<>("mode", OCNetworkMode.class, OCNetworkMode.NETWORK_ONLY));
     }
 
     @Nullable

--- a/src/main/java/pl/asie/ynot/oc/OCConnectorSettings.java
+++ b/src/main/java/pl/asie/ynot/oc/OCConnectorSettings.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 public class OCConnectorSettings extends TraitedConnectorSettings {
     TraitEnum<OCNetworkMode> networkMode;
 
+
     OCConnectorSettings(EnumFacing side) {
         super(side);
 


### PR DESCRIPTION
Additionally, this sneaks in the change to NETWORK_ONLY for the OC Cable's mode, to make it easier to build networks rapidly without risking too-manu-component computer errors.